### PR TITLE
add server proxy url with https

### DIFF
--- a/demos/00_A-Frame_starter/gulpfile.js
+++ b/demos/00_A-Frame_starter/gulpfile.js
@@ -17,7 +17,9 @@ var runSequence = require('run-sequence');
 gulp.task('browserSync', function() {
   browserSync({
     server: {
-      baseDir: 'app'
+      baseDir: 'app',
+      proxy: 'https://localhost:3000',
+      https: true 
     }
   })
 })


### PR DESCRIPTION
Hi @rdub80 I added a proxy with HTTPS. this seems to let the app run, but in chrome, it will give you an insecure warning. Just need to allow the URL to load manually.